### PR TITLE
fixed mobile menu bug

### DIFF
--- a/js/navigation.js
+++ b/js/navigation.js
@@ -11,7 +11,7 @@
 	if ( ! container )
 		return;
 
-	button = container.getElementsByTagName( 'button' )[0];
+	button = document.getElementsByClassName( 'menu-toggle' )[0];
 	if ( 'undefined' === typeof button )
 		return;
 
@@ -28,6 +28,7 @@
 		return;
 
 	button.onclick = function() {
+		
 		if ( -1 == menu.className.indexOf( 'mobile-menu' ) )
 			menu.className = 'menu';
 


### PR DESCRIPTION
Changed the menu selector in navigation.js, was returning undefined because it was looking inside the navigation container for the menu toggle button, which was outside of the navigation container.

changed to this line:
button = document.getElementsByClassName( 'menu-toggle' )[0];