### PR TITLE
make givingpress_lite_custom_logo() pluggable

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -241,7 +241,8 @@ require( get_template_directory() . '/includes/persist-admin-notices-dismissal/p
 /**
  * Custom logo function.
  */
-function givingpress_lite_custom_logo() {
+if ( ! function_exists ( 'givingpress_lite_custom_logo' ) ) {
+    function givingpress_lite_custom_logo() {
 
 	if ( function_exists( 'the_custom_logo' ) && has_custom_logo() ) {
 		the_custom_logo();
@@ -253,6 +254,7 @@ function givingpress_lite_custom_logo() {
 		<?php
 	}
 
+    }
 }
 
 /*


### PR DESCRIPTION
If people need to customize givingpress_lite_custom_logo() (e.g. display logo AND title)